### PR TITLE
Updating to 0.2.0 following FUSE mount release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The Python SDK for Accelerated Cloud Storage's Object Storage offering.
 
 `acs-sdk-python` is the ACS SDK for the Python programming language.
 
-The SDK requires a minimum version of Python 3.8.
+The SDK requires a minimum version of Python 3.10.
 
 Check out the [Release Notes] for information about the latest bug fixes, updates, and features added to the SDK.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "acs-sdk"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python SDK for Accelerated Cloud Storage service"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     { name = "AcceleratedCloudStorage", email = "sales@acceleratedcloudstorage.com" }
 ]
@@ -14,8 +14,6 @@ classifiers = [
     "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="acs-sdk",
-    version="0.1.0",
+    version="0.2.0",
     packages=find_packages(),
     install_requires=[
         "grpcio>=1.70.0",
@@ -35,8 +35,6 @@ setup(
         "License :: OSI Approved :: Mozilla Public License Version 2.0",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
This pull request includes several updates to the Python SDK for Accelerated Cloud Storage. The most important changes involve updating the minimum required Python version and bumping the SDK version. View more here: https://pypi.org/project/acs-sdk. This is directly related to the previous PR. 

### Updates to Python version requirements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6): Updated the minimum required Python version to 3.10.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R6): Updated the minimum required Python version to 3.10 and changed the package version to 0.2.0.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L17-L18): Removed Python 3.8 and 3.9 from the classifiers list.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L5-R5): Updated the package version to 0.2.0.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L38-L39): Removed Python 3.8 and 3.9 from the classifiers list.